### PR TITLE
Comment Support

### DIFF
--- a/jsonpp/error.hpp
+++ b/jsonpp/error.hpp
@@ -31,7 +31,7 @@ class parser_error : public std::exception {
 private:
     std::string error;
 public:
-    parser_error(const std::string& str, unsigned line, unsigned column):
+    parser_error(const std::string& str, std::size_t line, std::size_t column):
         error("stdin:" + std::to_string(line) + ':' + std::to_string(column) + ": error: " + str) {}
 
     const char* what() const JSONPP_NOEXCEPT override {

--- a/jsonpp/value.hpp
+++ b/jsonpp/value.hpp
@@ -92,10 +92,17 @@ public:
         storage.boolean = b;
     }
 
-
     template<typename T, EnableIf<is_string<T>, Not<is_bool<T>>> = 0>
     value(const T& str): storage_type(type::string) {
         storage.str = new std::string(str);
+    }
+
+    value(const char* str, std::size_t sz): storage_type(type::string) {
+        storage.str = new std::string(str, sz);
+    }
+
+    value(const char* str, const char* strend): storage_type(type::string) {
+        storage.str = new std::string(str, strend);
     }
 
     template<typename T, EnableIf<has_to_json<T>, Not<is_string<T>>, Not<is_bool<T>>> = 0>


### PR DESCRIPTION
This PR has comment support for jsonpp.

It also fixes warnings on x64 builds for the use of inherently std::size_t size values that are placed into parser_error's constructor and the parser's `column` and `line` attributes, getting rid of conversion warnings / errors.

Finally, the tests were not building in VS because VS does not support proper escapes in raw string literals when expanded in macros (and has issues with == in expressions). I am too lazy to file Yet Another Bug Report on Connect. Maybe next week or something.
