### PR TITLE
Fix ambiguous overload errors on VC++

### DIFF
--- a/jsonpp/dump.hpp
+++ b/jsonpp/dump.hpp
@@ -278,7 +278,7 @@ inline OStream& dump(OStream& out, const T& t, format_options opt = {}) {
     return out;
 }
 
-template<typename OStream, typename T, EnableIf<has_to_json<T>, Not<Or<is_object<T>, is_string<T>, is_array<T>>>> = 0>
+template<typename OStream, typename T, EnableIf<has_to_json<T>, Not<Or<is_object<T>, is_string<T>, is_array<T>, is_null<T>, is_bool<T>, is_number<T>>>> = 0>
 inline OStream& dump(OStream& out, const T& t, format_options opt = {}) {
     return dump(out, to_json(t), opt);
 }


### PR DESCRIPTION
Because VC++ can't keep its head together. Or its anything, really!

Simple fix for #15.
