### PR TITLE
Finishing touches for `canonical_(from|to)_json`.

### DIFF
--- a/jsonpp/canonical.hpp
+++ b/jsonpp/canonical.hpp
@@ -80,34 +80,34 @@ template<typename T, typename Sfinae = int>
 struct type_name;
 
 template<typename T> struct type_name<T, EnableIf<is_null<T>>> {
-    static const char* value;
+    static constexpr const char* value = "null";
 };
-template<typename T> const char* type_name<T, EnableIf<is_null<T>>>::value = "null";
+template<typename T> constexpr const char* type_name<T, EnableIf<is_null<T>>>::value;
 
 template<typename T> struct type_name<T, EnableIf<is_bool<T>>> {
-    static const char* value;
+    static constexpr const char* value = "boolean";
 };
-template<typename T> const char* type_name<T, EnableIf<is_bool<T>>>::value = "boolean";
+template<typename T> constexpr const char* type_name<T, EnableIf<is_bool<T>>>::value;
 
 template<typename T> struct type_name<T, EnableIf<is_number<T>>> {
-    static const char* value;
+    static constexpr const char* value = "number";
 };
-template<typename T> const char* type_name<T, EnableIf<is_number<T>>>::value = "number";
+template<typename T> constexpr const char* type_name<T, EnableIf<is_number<T>>>::value;
 
 template<typename T> struct type_name<T, EnableIf<is_string<T>>> {
-    static const char* value;
+    static constexpr const char* value = "string";
 };
-template<typename T> const char* type_name<T, EnableIf<is_string<T>>>::value = "string";
+template<typename T> constexpr const char* type_name<T, EnableIf<is_string<T>>>::value;
 
 template<typename T> struct type_name<T, EnableIf<is_object<T>>> {
-    static const char* value;
+    static constexpr const char* value = "object";
 };
-template<typename T> const char* type_name<T, EnableIf<is_object<T>>>::value = "object";
+template<typename T> constexpr const char* type_name<T, EnableIf<is_object<T>>>::value;
 
 template<typename T> struct type_name<T, EnableIf<is_array<T>>> {
-    static const char* value;
+    static constexpr const char* value = "array";
 };
-template<typename T> const char* type_name<T, EnableIf<is_array<T>>>::value = "array";
+template<typename T> constexpr const char* type_name<T, EnableIf<is_array<T>>>::value;
 
 template<typename Dest>
 struct canonical_from_json_type {

--- a/jsonpp/canonical.hpp
+++ b/jsonpp/canonical.hpp
@@ -123,18 +123,18 @@ private:
     >;
 
     template<typename Dep = void, EnableIf<is_json<Dep>> = 0>
-    static Dest impl(value const& v, int)
+    static void impl(value const& v, Dest& result, int)
     {
         if(!v.is<Dest>()) {
             std::ostringstream fmt;
             fmt << "expected a(n) " << type_name<Dest>::value << ", received a(n) " << v.type_name() << " instead";
             throw canonical_from_json_error { std::move(fmt).str() };
         }
-        return v.as<Dest>();
+        result = v.as<Dest>();
     }
 
     template<typename Dep = void, DisableIf<is_json<Dep>> = 0>
-    static Dest impl(value const& v, long)
+    static void impl(value const& v, Dest& result, long)
     {
         if(!v.is<object>()) {
             std::ostringstream fmt;
@@ -144,14 +144,16 @@ private:
 
         auto&& obj = v.as<object>();
         DependOn<from_json_algo, Dep> algo { obj };
-        Dest result;
         canonical_recipe<Dest> {}(algo, result);
-        return result;
     }
 
 public:
     Dest operator()(value const& v) const
-    { return impl(v, 0); }
+    {
+        Dest result;
+        impl(v, result, 0);
+        return result;
+    }
 };
 
 } // detail

--- a/jsonpp/canonical.hpp
+++ b/jsonpp/canonical.hpp
@@ -154,6 +154,11 @@ public:
         impl(v, result, 0);
         return result;
     }
+
+    void operator()(value const& v, Dest& result) const
+    {
+        impl(v, result, 0);
+    }
 };
 
 } // detail
@@ -163,6 +168,13 @@ Dest canonical_from_json(value const& v)
 {
     static constexpr detail::canonical_from_json_type<Dest> call;
     return call(v);
+}
+
+template<typename Dest>
+void canonical_from_json(value const& v, Dest& result)
+{
+    static constexpr detail::canonical_from_json_type<Dest> call;
+    call(v, result);
 }
 
 namespace detail {
@@ -181,7 +193,7 @@ struct from_json_algo {
         }
 
         try {
-            value = canonical_from_json<Value>(it->second);
+            canonical_from_json<Value>(it->second, value);
         } catch(canonical_from_json_error& e) {
             std::ostringstream fmt;
             fmt << "bad member '" << name << "': " << std::move(e).message;


### PR DESCRIPTION
`canonical_from_json` was very pessimistic in terms of default constructions and wasn’t fully exploiting the recipes/schemas in that respect. It now performs exactly one default construction, for the top-level destination type.

In addition another `canonical_from_json(json, result)` overload taking an out parameter and returning `void` had been added, allowing for zero default constructions. This functionality was underlying anyway after the change and exposing it to the user thus comes for free. It is also useful in that a top-level type that contains one or more non-default-constructible subobjects is unlikely to be default-constructible itself, esp. prior to C++14 extended aggregates.
